### PR TITLE
Feature/github-oauth

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -3,5 +3,22 @@
 # Generate at: https://github.com/settings/tokens
 GITHUB_TOKEN=your_github_token_here
 
-# GitHub API Base URL (usually no need to change)
+# GitHub API Base URL (通常は変更不要)
 GITHUB_API_BASE_URL=https://api.github.com
+
+# サーバーポート
+PORT=3000
+
+# フロントエンドURL（CORS設定用）
+FRONTEND_URL=http://localhost:5173
+
+# ========================================
+# GitHub OAuth App credentials
+# Create at: https://github.com/settings/developers
+# ========================================
+GITHUB_CLIENT_ID=your_client_id_here
+GITHUB_CLIENT_SECRET=your_client_secret_here
+
+# Session secret for cookie signing (generate a strong random string)
+# Generate with: openssl rand -base64 32
+SESSION_SECRET=your_session_secret_here

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,11 +15,13 @@
     "@git-canvas/shared": "workspace:*",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "express-session": "^1.18.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
+    "@types/express-session": "^1.18.2",
     "@types/node": "^24.10.4",
     "@types/supertest": "^6.0.3",
     "@vitest/coverage-v8": "^4.0.16",

--- a/packages/backend/src/__tests__/routes/auth.test.ts
+++ b/packages/backend/src/__tests__/routes/auth.test.ts
@@ -1,0 +1,72 @@
+import express, { type Express } from 'express';
+import session from 'express-session';
+import request from 'supertest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { authRouter } from '../../routes/auth.js';
+
+describe('Auth Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    // テスト用アプリケーション作成
+    app = express();
+    app.use(express.json());
+    app.use(
+      session({
+        secret: 'test-secret',
+        resave: false,
+        saveUninitialized: false,
+      })
+    );
+    app.use('/api/auth', authRouter);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 環境変数をモック
+    process.env.GITHUB_CLIENT_ID = 'test-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'test-client-secret';
+    process.env.FRONTEND_URL = 'http://localhost:5173';
+  });
+
+  describe('GET /api/auth/login', () => {
+    it('GitHubの認証ページにリダイレクトする', async () => {
+      const response = await request(app).get('/api/auth/login');
+
+      expect(response.status).toBe(302);
+      expect(response.headers.location).toContain('https://github.com/login/oauth/authorize');
+      expect(response.headers.location).toContain('client_id=test-client-id');
+      expect(response.headers.location).toContain('scope=read%3Auser');
+    });
+  });
+
+  describe('GET /api/auth/callback', () => {
+    it('codeがない場合は400エラーを返す', async () => {
+      const response = await request(app).get('/api/auth/callback');
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Authorization code is required');
+    });
+  });
+
+  describe('GET /api/auth/me', () => {
+    it('未ログイン時は authenticated: false を返す', async () => {
+      const response = await request(app).get('/api/auth/me');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        authenticated: false,
+        user: null,
+      });
+    });
+  });
+
+  describe('GET /api/auth/logout', () => {
+    it('ログアウト成功メッセージを返す', async () => {
+      const response = await request(app).get('/api/auth/logout');
+
+      expect(response.status).toBe(200);
+      expect(response.body.message).toBe('Logged out successfully');
+    });
+  });
+});

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,6 +1,7 @@
 import cors from 'cors';
 import express, { type Express } from 'express';
 import session from 'express-session';
+import { authRouter } from './routes/auth.js';
 import { healthRouter } from './routes/health.js';
 import { createRepositoryRouter } from './routes/repository.js';
 
@@ -45,6 +46,7 @@ export const createApp = (): Express => {
   app.use(express.urlencoded({ extended: true }));
 
   // ルーター設定
+  app.use('/api/auth', authRouter);
   app.use('/api/health', healthRouter);
   app.use('/api/repositories', createRepositoryRouter());
 

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -1,5 +1,6 @@
 import cors from 'cors';
 import express, { type Express } from 'express';
+import session from 'express-session';
 import { healthRouter } from './routes/health.js';
 import { createRepositoryRouter } from './routes/repository.js';
 
@@ -18,7 +19,22 @@ export const createApp = (): Express => {
   app.use(
     cors({
       origin: process.env.FRONTEND_URL ?? 'http://localhost:5173',
-      credentials: true,
+      credentials: true, // Cookie送信を許可
+    })
+  );
+
+  // セッション設定
+  app.use(
+    session({
+      secret: process.env.SESSION_SECRET ?? 'dev-secret-change-in-production',
+      resave: false,
+      saveUninitialized: false,
+      cookie: {
+        httpOnly: true, // JavaScriptからアクセス不可（XSS対策）
+        secure: process.env.NODE_ENV === 'production', // 本番はHTTPSのみ
+        sameSite: 'lax', // CSRF対策
+        maxAge: 24 * 60 * 60 * 1000, // 24時間
+      },
     })
   );
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,8 +1,9 @@
 import dotenv from 'dotenv';
-import { createApp } from './app.js';
 
 // 環境変数の読み込み(.envファイル)
 dotenv.config();
+
+import { createApp } from './app.js';
 
 const PORT = Number(process.env.PORT) || 3000;
 const app = createApp();

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -1,0 +1,159 @@
+import { type Request, type Response, Router } from 'express';
+
+/**
+ * セッションに保存するユーザー情報の型
+ */
+declare module 'express-session' {
+  interface SessionData {
+    accessToken?: string;
+    user?: {
+      id: number;
+      login: string;
+      name: string | null;
+      avatarUrl: string;
+    };
+  }
+}
+
+/**
+ * GitHub OAuth の設定
+ */
+const GITHUB_OAUTH_CONFIG = {
+  clientId: process.env.GITHUB_CLIENT_ID ?? '',
+  clientSecret: process.env.GITHUB_CLIENT_SECRET ?? '',
+  authorizeUrl: 'https://github.com/login/oauth/authorize',
+  tokenUrl: 'https://github.com/login/oauth/access_token',
+  userApiUrl: 'https://api.github.com/user',
+  scope: 'read:user', // ユーザー情報の読み取りのみ
+};
+
+export const authRouter = Router();
+
+/**
+ * GET /api/auth/login
+ * GitHubの認証ページにリダイレクト
+ */
+authRouter.get('/login', (_req: Request, res: Response): void => {
+  const params = new URLSearchParams({
+    client_id: GITHUB_OAUTH_CONFIG.clientId,
+    scope: GITHUB_OAUTH_CONFIG.scope,
+    redirect_uri: `${process.env.FRONTEND_URL ?? 'http://localhost:5173'}/api/auth/callback`,
+  });
+
+  const authUrl = `${GITHUB_OAUTH_CONFIG.authorizeUrl}?${params.toString()}`;
+  res.redirect(authUrl);
+});
+
+/**
+ * GET /api/auth/callback
+ * GitHubからのコールバック処理
+ */
+authRouter.get('/callback', async (req: Request, res: Response): Promise<void> => {
+  const { code } = req.query;
+
+  // codeがない場合はエラー
+  if (!code || typeof code !== 'string') {
+    res.status(400).json({ error: 'Authorization code is required' });
+    return;
+  }
+
+  try {
+    // Step 1: codeをアクセストークンに交換
+    const tokenResponse = await fetch(GITHUB_OAUTH_CONFIG.tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: GITHUB_OAUTH_CONFIG.clientId,
+        client_secret: GITHUB_OAUTH_CONFIG.clientSecret,
+        code,
+      }),
+    });
+
+    const tokenData = (await tokenResponse.json()) as {
+      access_token?: string;
+      error?: string;
+      error_description?: string;
+    };
+
+    if (tokenData.error || !tokenData.access_token) {
+      console.error('Token exchange failed:', tokenData);
+      res.status(400).json({
+        error: 'Failed to exchange code for token',
+        message: tokenData.error_description ?? tokenData.error,
+      });
+      return;
+    }
+
+    // Step 2: アクセストークンでユーザー情報を取得
+    const userResponse = await fetch(GITHUB_OAUTH_CONFIG.userApiUrl, {
+      headers: {
+        Authorization: `Bearer ${tokenData.access_token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+
+    if (!userResponse.ok) {
+      res.status(500).json({ error: 'Failed to fetch user info' });
+      return;
+    }
+
+    const userData = (await userResponse.json()) as {
+      id: number;
+      login: string;
+      name: string | null;
+      avatar_url: string;
+    };
+
+    // Step 3: セッションに保存
+    req.session.accessToken = tokenData.access_token;
+    req.session.user = {
+      id: userData.id,
+      login: userData.login,
+      name: userData.name,
+      avatarUrl: userData.avatar_url,
+    };
+
+    // Step 4: フロントエンドにリダイレクト
+    res.redirect(process.env.FRONTEND_URL ?? 'http://localhost:5173');
+  } catch (error) {
+    console.error('OAuth callback error:', error);
+    res.status(500).json({ error: 'Internal server error during authentication' });
+  }
+});
+
+/**
+ * GET /api/auth/logout
+ * ログアウト（セッション破棄）
+ */
+authRouter.get('/logout', (req: Request, res: Response): void => {
+  req.session.destroy((err) => {
+    if (err) {
+      console.error('Session destroy error:', err);
+      res.status(500).json({ error: 'Failed to logout' });
+      return;
+    }
+    res.clearCookie('connect.sid'); // セッションCookieを削除
+    res.json({ message: 'Logged out successfully' });
+  });
+});
+
+/**
+ * GET /api/auth/me
+ * 現在のログイン状態を取得
+ */
+authRouter.get('/me', (req: Request, res: Response): void => {
+  if (req.session.user) {
+    res.json({
+      authenticated: true,
+      user: req.session.user,
+    });
+  } else {
+    res.json({
+      authenticated: false,
+      user: null,
+    });
+  }
+});

--- a/packages/frontend/src/App.css
+++ b/packages/frontend/src/App.css
@@ -5,20 +5,27 @@
 }
 
 /* ヘッダー */
-.App h1 {
+.App-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing-xl) var(--spacing-lg);
+  max-width: var(--max-width-container);
+  margin: 0 auto;
+}
+
+.App-header h1 {
   background: var(--gradient-primary);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  font-size: 3rem;
+  font-size: 2rem;
   font-weight: 800;
-  text-align: center;
-  padding: var(--spacing-xl) 0 var(--spacing-sm) 0; /* 下のpaddingを小さく */
   margin: 0;
   letter-spacing: -0.02em;
 }
 
-/* サブタイトル追加 */
+/* サブタイトル */
 .App-subtitle {
   text-align: center;
   color: var(--color-text-secondary);
@@ -28,7 +35,7 @@
 }
 
 /* コンテナ */
-.App > div {
+.App > div:last-child {
   max-width: var(--max-width-container);
   margin: 0 auto;
   padding: 0 var(--spacing-lg);
@@ -36,9 +43,14 @@
 
 /* レスポンシブ */
 @media (max-width: 768px) {
-  .App h1 {
-    font-size: 2rem;
-    padding: var(--spacing-lg) 0 var(--spacing-xs) 0;
+  .App-header {
+    flex-direction: column;
+    gap: var(--spacing-md);
+    padding: var(--spacing-lg) var(--spacing-md);
+  }
+
+  .App-header h1 {
+    font-size: 1.5rem;
   }
 
   .App-subtitle {
@@ -46,7 +58,7 @@
     padding-bottom: var(--spacing-lg);
   }
 
-  .App > div {
+  .App > div:last-child {
     padding: 0 var(--spacing-md);
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,10 +1,14 @@
 import './App.css';
+import { LoginButton } from './components/Auth/LoginButton';
 import { RepositoryViewer } from './components/Repository/RepositoryViewer';
 
 const App = () => {
   return (
     <div className="App">
-      <h1>🎨 GitCanvas</h1>
+      <header className="App-header">
+        <h1>🎨 GitCanvas</h1>
+        <LoginButton />
+      </header>
       <p className="App-subtitle">Paint your Git history</p>
       <RepositoryViewer owner="Sottiki" repo="git-canvas" />
     </div>

--- a/packages/frontend/src/api/__tests__/authApi.test.ts
+++ b/packages/frontend/src/api/__tests__/authApi.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthStatusResponse } from '../authApi';
+import { fetchAuthStatus, getLoginUrl, logout } from '../authApi';
+
+// fetchをモック化
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+describe('authApi', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('fetchAuthStatus', () => {
+    it('認証済みの場合、ユーザー情報を返す', async () => {
+      // Arrange
+      const mockResponse: AuthStatusResponse = {
+        authenticated: true,
+        user: {
+          id: 123,
+          login: 'testuser',
+          name: 'Test User',
+          avatarUrl: 'https://example.com/avatar.png',
+        },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      // Act
+      const result = await fetchAuthStatus();
+
+      // Assert
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/api/auth/me', {
+        credentials: 'include',
+      });
+    });
+
+    it('未認証の場合、authenticated: falseを返す', async () => {
+      // Arrange
+      const mockResponse: AuthStatusResponse = {
+        authenticated: false,
+        user: null,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      // Act
+      const result = await fetchAuthStatus();
+
+      // Assert
+      expect(result).toEqual(mockResponse);
+      expect(result.authenticated).toBe(false);
+      expect(result.user).toBeNull();
+    });
+
+    it('APIエラーの場合、エラーを投げる', async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Internal Server Error',
+      });
+
+      // Act & Assert
+      await expect(fetchAuthStatus()).rejects.toThrow(
+        'Failed to fetch auth status: Internal Server Error'
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('正常にログアウトできる', async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+      });
+
+      // Act & Assert
+      await expect(logout()).resolves.toBeUndefined();
+      expect(mockFetch).toHaveBeenCalledWith('http://localhost:3000/api/auth/logout', {
+        credentials: 'include',
+      });
+    });
+
+    it('APIエラーの場合、エラーを投げる', async () => {
+      // Arrange
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        statusText: 'Unauthorized',
+      });
+
+      // Act & Assert
+      await expect(logout()).rejects.toThrow('Failed to logout: Unauthorized');
+    });
+  });
+
+  describe('getLoginUrl', () => {
+    it('ログインURLを返す', () => {
+      // Act
+      const url = getLoginUrl();
+
+      // Assert
+      expect(url).toBe('http://localhost:3000/api/auth/login');
+    });
+  });
+});

--- a/packages/frontend/src/api/authApi.ts
+++ b/packages/frontend/src/api/authApi.ts
@@ -1,0 +1,42 @@
+import type { AuthStatusResponse, AuthUser } from '@git-canvas/shared/types';
+
+// 型定義を再エクスポート（他のファイルで使いやすくするため）
+export type { AuthStatusResponse, AuthUser };
+
+// APIのベースURL
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
+
+/**
+ * 現在の認証状態を取得
+ */
+export const fetchAuthStatus = async (): Promise<AuthStatusResponse> => {
+  const response = await fetch(`${API_BASE_URL}/auth/me`, {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch auth status: ${response.statusText}`);
+  }
+
+  return response.json();
+};
+
+/**
+ * ログアウト
+ */
+export const logout = async (): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/auth/logout`, {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to logout: ${response.statusText}`);
+  }
+};
+
+/**
+ * ログインページのURLを取得
+ */
+export const getLoginUrl = (): string => {
+  return `${API_BASE_URL}/auth/login`;
+};

--- a/packages/frontend/src/components/Auth/LoginButton.module.css
+++ b/packages/frontend/src/components/Auth/LoginButton.module.css
@@ -1,0 +1,71 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+/* ログインボタン */
+.loginButton {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background: #24292e;
+  color: white;
+  border-radius: var(--radius-md);
+  font-weight: 500;
+  font-size: 0.875rem;
+  transition: all var(--transition-base);
+}
+
+.loginButton:hover {
+  background: #2f363d;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
+}
+
+/* ユーザー情報 */
+.userInfo {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid var(--color-border-light);
+}
+
+.username {
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+/* ログアウトボタン */
+.logoutButton {
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-medium);
+  border-radius: var(--radius-md);
+  font-size: 0.75rem;
+  transition: all var(--transition-base);
+}
+
+.logoutButton:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+
+/* ローディング */
+.loading {
+  color: var(--color-text-tertiary);
+  font-size: 0.875rem;
+}

--- a/packages/frontend/src/components/Auth/LoginButton.tsx
+++ b/packages/frontend/src/components/Auth/LoginButton.tsx
@@ -1,0 +1,61 @@
+import { useAuth } from '../../hooks/useAuth';
+import styles from './LoginButton.module.css';
+
+/**
+ * ログイン/ログアウトボタンコンポーネント
+ *
+ * - 未ログイン時: 「GitHubでログイン」ボタンを表示
+ * - ログイン時: ユーザー情報とログアウトボタンを表示
+ */
+export const LoginButton = () => {
+  const { user, loading, isAuthenticated, login, logout } = useAuth();
+
+  // ローディング中
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <span className={styles.loading}>Loading...</span>
+      </div>
+    );
+  }
+
+  // 未ログイン
+  if (!isAuthenticated) {
+    return (
+      <div className={styles.container}>
+        <button type="button" className={styles.loginButton} onClick={login}>
+          <GitHubIcon />
+          GitHubでログイン
+        </button>
+      </div>
+    );
+  }
+
+  // ログイン済み
+  return (
+    <div className={styles.container}>
+      <div className={styles.userInfo}>
+        <img src={user?.avatarUrl} alt={user?.login} className={styles.avatar} />
+        <span className={styles.username}>{user?.login}</span>
+      </div>
+      <button type="button" className={styles.logoutButton} onClick={logout}>
+        ログアウト
+      </button>
+    </div>
+  );
+};
+
+/**
+ * GitHubアイコン（SVG）
+ */
+const GitHubIcon = () => (
+  <svg
+    className={styles.icon}
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+  </svg>
+);

--- a/packages/frontend/src/components/Auth/__tests__/LoginButton.test.tsx
+++ b/packages/frontend/src/components/Auth/__tests__/LoginButton.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as useAuthModule from '../../../hooks/useAuth';
+import { LoginButton } from '../LoginButton';
+
+// useAuthフックをモック化
+vi.mock('../../../hooks/useAuth');
+
+describe('LoginButton', () => {
+  const mockLogin = vi.fn();
+  const mockLogout = vi.fn();
+  const mockRefetch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ローディング中は「Loading...」を表示する', () => {
+    // Arrange
+    vi.mocked(useAuthModule.useAuth).mockReturnValue({
+      user: null,
+      loading: true,
+      isAuthenticated: false,
+      login: mockLogin,
+      logout: mockLogout,
+      refetch: mockRefetch,
+    });
+
+    // Act
+    render(<LoginButton />);
+
+    // Assert
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('未ログイン時は「GitHubでログイン」ボタンを表示する', () => {
+    // Arrange
+    vi.mocked(useAuthModule.useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+      isAuthenticated: false,
+      login: mockLogin,
+      logout: mockLogout,
+      refetch: mockRefetch,
+    });
+
+    // Act
+    render(<LoginButton />);
+
+    // Assert
+    expect(screen.getByRole('button', { name: /GitHubでログイン/i })).toBeInTheDocument();
+  });
+
+  it('未ログイン時にボタンをクリックするとlogin()が呼ばれる', async () => {
+    // Arrange
+    vi.mocked(useAuthModule.useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+      isAuthenticated: false,
+      login: mockLogin,
+      logout: mockLogout,
+      refetch: mockRefetch,
+    });
+    const user = userEvent.setup();
+
+    // Act
+    render(<LoginButton />);
+    await user.click(screen.getByRole('button', { name: /GitHubでログイン/i }));
+
+    // Assert
+    expect(mockLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('ログイン済みはユーザー名とアバターを表示する', () => {
+    // Arrange
+    const mockUser = {
+      id: 123,
+      login: 'testuser',
+      name: 'Test User',
+      avatarUrl: 'https://example.com/avatar.png',
+    };
+    vi.mocked(useAuthModule.useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      isAuthenticated: true,
+      login: mockLogin,
+      logout: mockLogout,
+      refetch: mockRefetch,
+    });
+
+    // Act
+    render(<LoginButton />);
+
+    // Assert
+    expect(screen.getByText('testuser')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'testuser' })).toHaveAttribute(
+      'src',
+      'https://example.com/avatar.png'
+    );
+  });
+
+  it('ログイン済みは「ログアウト」ボタンを表示する', () => {
+    // Arrange
+    const mockUser = {
+      id: 123,
+      login: 'testuser',
+      name: 'Test User',
+      avatarUrl: 'https://example.com/avatar.png',
+    };
+    vi.mocked(useAuthModule.useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      isAuthenticated: true,
+      login: mockLogin,
+      logout: mockLogout,
+      refetch: mockRefetch,
+    });
+
+    // Act
+    render(<LoginButton />);
+
+    // Assert
+    expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument();
+  });
+
+  it('ログイン済みにログアウトボタンをクリックするとlogout()が呼ばれる', async () => {
+    // Arrange
+    const mockUser = {
+      id: 123,
+      login: 'testuser',
+      name: 'Test User',
+      avatarUrl: 'https://example.com/avatar.png',
+    };
+    vi.mocked(useAuthModule.useAuth).mockReturnValue({
+      user: mockUser,
+      loading: false,
+      isAuthenticated: true,
+      login: mockLogin,
+      logout: mockLogout,
+      refetch: mockRefetch,
+    });
+    const user = userEvent.setup();
+
+    // Act
+    render(<LoginButton />);
+    await user.click(screen.getByRole('button', { name: 'ログアウト' }));
+
+    // Assert
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/frontend/src/hooks/__tests__/useAuth.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,209 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthStatusResponse } from '../../api/authApi';
+import * as authApi from '../../api/authApi';
+import { useAuth } from '../useAuth';
+
+// authApiモジュールをモック化
+vi.mock('../../api/authApi', async () => {
+  const actual = await vi.importActual('../../api/authApi');
+  return {
+    ...actual,
+    fetchAuthStatus: vi.fn(),
+    logout: vi.fn(),
+  };
+});
+
+// window.location.hrefをモック化
+const mockLocationHref = vi.fn();
+const originalLocation = window.location;
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // window.locationをモック
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        set href(url: string) {
+          mockLocationHref(url);
+        },
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    // window.locationを元に戻す
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('初期状態はloading: trueである', () => {
+    // Arrange
+    vi.mocked(authApi.fetchAuthStatus).mockImplementation(
+      () => new Promise(() => {}) // 永遠にpending
+    );
+
+    // Act
+    const { result } = renderHook(() => useAuth());
+
+    // Assert
+    expect(result.current.loading).toBe(true);
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('認証済みの場合、ユーザー情報を取得する', async () => {
+    // Arrange
+    const mockUser = {
+      id: 123,
+      login: 'testuser',
+      name: 'Test User',
+      avatarUrl: 'https://example.com/avatar.png',
+    };
+    const mockResponse: AuthStatusResponse = {
+      authenticated: true,
+      user: mockUser,
+    };
+    vi.mocked(authApi.fetchAuthStatus).mockResolvedValueOnce(mockResponse);
+
+    // Act
+    const { result } = renderHook(() => useAuth());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('未認証の場合、user: nullになる', async () => {
+    // Arrange
+    const mockResponse: AuthStatusResponse = {
+      authenticated: false,
+      user: null,
+    };
+    vi.mocked(authApi.fetchAuthStatus).mockResolvedValueOnce(mockResponse);
+
+    // Act
+    const { result } = renderHook(() => useAuth());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('login()でログインURLにリダイレクトする', async () => {
+    // Arrange
+    const mockResponse: AuthStatusResponse = {
+      authenticated: false,
+      user: null,
+    };
+    vi.mocked(authApi.fetchAuthStatus).mockResolvedValueOnce(mockResponse);
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Act
+    act(() => {
+      result.current.login();
+    });
+
+    // Assert
+    expect(mockLocationHref).toHaveBeenCalledWith('http://localhost:3000/api/auth/login');
+  });
+
+  it('logout()でユーザー情報がクリアされる', async () => {
+    // Arrange
+    const mockUser = {
+      id: 123,
+      login: 'testuser',
+      name: 'Test User',
+      avatarUrl: 'https://example.com/avatar.png',
+    };
+    vi.mocked(authApi.fetchAuthStatus).mockResolvedValueOnce({
+      authenticated: true,
+      user: mockUser,
+    });
+    vi.mocked(authApi.logout).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    // Act
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    // Assert
+    expect(authApi.logout).toHaveBeenCalled();
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('refetch()で認証状態を再取得できる', async () => {
+    // Arrange: 最初は未認証
+    vi.mocked(authApi.fetchAuthStatus).mockResolvedValueOnce({
+      authenticated: false,
+      user: null,
+    });
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.isAuthenticated).toBe(false);
+
+    // Arrange: 次の呼び出しでは認証済み
+    const mockUser = {
+      id: 123,
+      login: 'testuser',
+      name: 'Test User',
+      avatarUrl: 'https://example.com/avatar.png',
+    };
+    vi.mocked(authApi.fetchAuthStatus).mockResolvedValueOnce({
+      authenticated: true,
+      user: mockUser,
+    });
+
+    // Act
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    // Assert
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  it('fetchAuthStatusがエラーの場合、user: nullになる', async () => {
+    // Arrange
+    vi.mocked(authApi.fetchAuthStatus).mockRejectedValueOnce(new Error('Network error'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Act
+    const { result } = renderHook(() => useAuth());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.user).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch auth status:', expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/frontend/src/hooks/useAuth.ts
+++ b/packages/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react';
+import { type AuthUser, fetchAuthStatus, getLoginUrl, logout as logoutApi } from '../api/authApi';
+
+/**
+ * useAuth フックの戻り値の型
+ */
+interface UseAuthReturn {
+  /** ログイン中のユーザー情報（未ログインならnull） */
+  user: AuthUser | null;
+  /** 認証状態の読み込み中かどうか */
+  loading: boolean;
+  /** 認証済みかどうか */
+  isAuthenticated: boolean;
+  /** ログインページに遷移 */
+  login: () => void;
+  /** ログアウト処理 */
+  logout: () => Promise<void>;
+  /** 認証状態を再取得 */
+  refetch: () => Promise<void>;
+}
+
+/**
+ * 認証状態を管理するカスタムフック
+ */
+export const useAuth = (): UseAuthReturn => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  // 認証状態を取得する関数
+  const refetch = useCallback(async () => {
+    try {
+      setLoading(true);
+      const status = await fetchAuthStatus();
+      setUser(status.user);
+    } catch (error) {
+      console.error('Failed to fetch auth status:', error);
+      setUser(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // 初回マウント時に認証状態を取得
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  // ログイン処理（GitHubにリダイレクト）
+  const login = useCallback(() => {
+    window.location.href = getLoginUrl();
+  }, []);
+
+  // ログアウト処理
+  const logout = useCallback(async () => {
+    try {
+      await logoutApi();
+      setUser(null);
+    } catch (error) {
+      console.error('Failed to logout:', error);
+    }
+  }, []);
+
+  return {
+    user,
+    loading,
+    isAuthenticated: user !== null,
+    login,
+    logout,
+    refetch,
+  };
+};

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -1,0 +1,28 @@
+/**
+ * 認証関連の型定義
+ */
+
+/**
+ * 認証済みユーザー情報
+ */
+export interface AuthUser {
+  /** GitHubユーザーID */
+  id: number;
+  /** GitHubユーザー名 */
+  login: string;
+  /** 表示名（設定されていない場合はnull） */
+  name: string | null;
+  /** アバター画像URL */
+  avatarUrl: string;
+}
+
+/**
+ * 認証状態のレスポンス型
+ * GET /api/auth/me のレスポンス
+ */
+export interface AuthStatusResponse {
+  /** 認証済みかどうか */
+  authenticated: boolean;
+  /** ユーザー情報（未認証の場合はnull） */
+  user: AuthUser | null;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -2,6 +2,7 @@
  * 型定義のエクスポート
  */
 export type { HealthResponse, HealthStatus } from './api.js';
+export type { AuthStatusResponse, AuthUser } from './auth.js';
 export type { CanvasAuthor, CanvasBranch, CanvasCommit, CanvasRepository } from './canvas.js';
 export type { ErrorResponse } from './error.js';
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-session:
+        specifier: ^1.18.2
+        version: 1.18.2
     devDependencies:
       '@types/cors':
         specifier: ^2.8.19
@@ -33,6 +36,9 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
+      '@types/express-session':
+        specifier: ^1.18.2
+        version: 1.18.2
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.4
@@ -762,6 +768,9 @@ packages:
   '@types/express-serve-static-core@5.1.0':
     resolution: {integrity: sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==}
 
+  '@types/express-session@1.18.2':
+    resolution: {integrity: sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==}
+
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
@@ -1063,6 +1072,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -1099,6 +1111,14 @@ packages:
   data-urls@6.0.0:
     resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
     engines: {node: '>=20'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1256,6 +1276,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-session@1.18.2:
+    resolution: {integrity: sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==}
+    engines: {node: '>= 0.8.0'}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -1635,6 +1659,9 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1675,6 +1702,10 @@ packages:
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -1755,6 +1786,10 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  random-bytes@1.0.0:
+    resolution: {integrity: sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==}
+    engines: {node: '>= 0.8'}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -1806,6 +1841,9 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1992,6 +2030,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uid-safe@2.1.5:
+    resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
+    engines: {node: '>= 0.8'}
 
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
@@ -2677,6 +2719,10 @@ snapshots:
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
+  '@types/express-session@1.18.2':
+    dependencies:
+      '@types/express': 5.0.6
+
   '@types/express@5.0.6':
     dependencies:
       '@types/body-parser': 1.19.6
@@ -3049,6 +3095,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.0.7: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -3085,6 +3133,10 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
@@ -3267,6 +3319,19 @@ snapshots:
   etag@1.8.1: {}
 
   expect-type@1.3.0: {}
+
+  express-session@1.18.2:
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      on-headers: 1.1.0
+      parseurl: 1.3.3
+      safe-buffer: 5.2.1
+      uid-safe: 2.1.5
+    transitivePeerDependencies:
+      - supports-color
 
   express@5.2.1:
     dependencies:
@@ -3653,6 +3718,8 @@ snapshots:
 
   mrmime@2.0.1: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -3687,6 +3754,8 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:
@@ -3760,6 +3829,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  random-bytes@1.0.0: {}
+
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -3832,6 +3903,8 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
@@ -4033,6 +4106,10 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uid-safe@2.1.5:
+    dependencies:
+      random-bytes: 1.0.0
 
   undefsafe@2.0.5: {}
 


### PR DESCRIPTION
## 概要
GitHubアカウントでログインできる機能を追加

## 変更内容

### バックエンド
- express-sessionによるセッション管理
- 認証ルーター（/api/auth/login, callback, logout, me）
- GitHub OAuth認証フロー実装

### フロントエンド
- authApi: 認証API関数
- useAuth: 認証状態管理フック
- LoginButton: ログイン/ログアウトUIコンポーネント

### 共通
- AuthUser, AuthStatusResponse 型定義を shared パッケージに追加

## テスト
- バックエンド: 認証ルーターのテスト（supertest）
- フロントエンド: API関数、フック、コンポーネントのテスト

## 動作確認
- [x] GitHubでログインできる
- [x] ユーザー情報が表示される
- [x] ログアウトできる
- [x] 全テストがパス