### PR TITLE
Add commit detail modal and enhance commit interactions

### DIFF
--- a/packages/backend/src/__tests__/routes/health.test.ts
+++ b/packages/backend/src/__tests__/routes/health.test.ts
@@ -1,29 +1,22 @@
-import type { Server } from 'node:http';
 import type { HealthResponse } from '@git-canvas/shared';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { createApp } from '../../app.js';
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { healthRouter } from '../../routes/health.js';
 
 describe('Health Check API', () => {
-  let server: Server;
-  const PORT = 3001; // テスト用ポート (本番は 3000)
-
-  beforeAll(() => {
-    const app = createApp();
-    server = app.listen(PORT);
-  });
-
-  afterAll(() => {
-    server.close();
-  });
+  // テスト用のExpressアプリを作成（サーバーを起動しない）
+  const app = express();
+  app.use('/api/health', healthRouter);
 
   it('should return 200 status', async () => {
-    const response = await fetch(`http://localhost:${PORT}/api/health`);
+    const response = await request(app).get('/api/health');
     expect(response.status).toBe(200);
   });
 
   it('should return correct structure', async () => {
-    const response = await fetch(`http://localhost:${PORT}/api/health`);
-    const data = (await response.json()) as HealthResponse;
+    const response = await request(app).get('/api/health');
+    const data = response.body as HealthResponse;
 
     expect(data).toHaveProperty('status');
     expect(data).toHaveProperty('timestamp');
@@ -31,15 +24,15 @@ describe('Health Check API', () => {
   });
 
   it('should return status "ok"', async () => {
-    const response = await fetch(`http://localhost:${PORT}/api/health`);
-    const data = (await response.json()) as HealthResponse;
+    const response = await request(app).get('/api/health');
+    const data = response.body as HealthResponse;
 
     expect(data.status).toBe('ok');
   });
 
   it('should return valid timestamp', async () => {
-    const response = await fetch(`http://localhost:${PORT}/api/health`);
-    const data = (await response.json()) as HealthResponse;
+    const response = await request(app).get('/api/health');
+    const data = response.body as HealthResponse;
 
     const timestamp = new Date(data.timestamp);
     expect(timestamp).toBeInstanceOf(Date);
@@ -47,8 +40,8 @@ describe('Health Check API', () => {
   });
 
   it('should return positive uptime', async () => {
-    const response = await fetch(`http://localhost:${PORT}/api/health`);
-    const data = (await response.json()) as HealthResponse;
+    const response = await request(app).get('/api/health');
+    const data = response.body as HealthResponse;
 
     expect(data.uptime).toBeGreaterThan(0);
     expect(typeof data.uptime).toBe('number');

--- a/packages/backend/src/__tests__/services/githubConverter.test.ts
+++ b/packages/backend/src/__tests__/services/githubConverter.test.ts
@@ -1,6 +1,10 @@
-import type { GitHubBranch, GitHubCommit } from '@git-canvas/shared/types';
+import type { GitHubBranch, GitHubCommit, GitHubCommitWithFiles } from '@git-canvas/shared/types';
 import { describe, expect, it } from 'vitest';
-import { convertToCanvasBranch, convertToCanvasCommit } from '../../services/githubConverter.js';
+import {
+  convertToCanvasBranch,
+  convertToCanvasCommit,
+  convertToCommitDetail,
+} from '../../services/githubConverter.js';
 
 describe('githubConverter', () => {
   describe('convertToCanvasCommit', () => {
@@ -155,6 +159,239 @@ describe('githubConverter', () => {
       const result = convertToCanvasBranch(githubBranch);
 
       expect(result.isProtected).toBe(false);
+    });
+  });
+
+  describe('convertToCommitDetail', () => {
+    it('GitHub APIのコミット詳細情報をCommitDetail型に正しく変換する', () => {
+      // Arrange: テストデータ準備
+      const githubCommitWithFiles: GitHubCommitWithFiles = {
+        sha: 'abc123def456789012345678901234567890abcd',
+        commit: {
+          author: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          committer: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          message: 'Test commit',
+          tree: { sha: 'tree123' },
+          comment_count: 0,
+        },
+        author: null,
+        committer: null,
+        parents: [],
+        html_url: 'https://github.com/owner/repo/commit/abc123',
+        files: [
+          {
+            filename: 'src/index.ts',
+            status: 'modified',
+            additions: 10,
+            deletions: 5,
+            changes: 15,
+          },
+          {
+            filename: 'README.md',
+            status: 'added',
+            additions: 20,
+            deletions: 0,
+            changes: 20,
+          },
+        ],
+        stats: {
+          total: 35,
+          additions: 30,
+          deletions: 5,
+        },
+      };
+
+      // Act: 変換実行
+      const result = convertToCommitDetail(githubCommitWithFiles);
+
+      // Assert: 期待値検証
+      expect(result).toEqual({
+        sha: 'abc123def456789012345678901234567890abcd',
+        files: [
+          {
+            filename: 'src/index.ts',
+            status: 'modified',
+            additions: 10,
+            deletions: 5,
+            changes: 15,
+            previousFilename: undefined,
+          },
+          {
+            filename: 'README.md',
+            status: 'added',
+            additions: 20,
+            deletions: 0,
+            changes: 20,
+            previousFilename: undefined,
+          },
+        ],
+        stats: {
+          total: 35,
+          additions: 30,
+          deletions: 5,
+        },
+      });
+    });
+
+    it('リネームされたファイルのprevious_filenameを正しく変換する', () => {
+      // Arrange
+      const githubCommitWithFiles: GitHubCommitWithFiles = {
+        sha: 'rename123',
+        commit: {
+          author: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          committer: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          message: 'Rename file',
+          tree: { sha: 'tree123' },
+          comment_count: 0,
+        },
+        author: null,
+        committer: null,
+        parents: [],
+        html_url: 'https://github.com/owner/repo/commit/rename123',
+        files: [
+          {
+            filename: 'new-name.ts',
+            status: 'renamed',
+            additions: 0,
+            deletions: 0,
+            changes: 0,
+            previous_filename: 'old-name.ts',
+          },
+        ],
+        stats: {
+          total: 0,
+          additions: 0,
+          deletions: 0,
+        },
+      };
+
+      // Act
+      const result = convertToCommitDetail(githubCommitWithFiles);
+
+      // Assert
+      expect(result.files[0]).toEqual({
+        filename: 'new-name.ts',
+        status: 'renamed',
+        additions: 0,
+        deletions: 0,
+        changes: 0,
+        previousFilename: 'old-name.ts',
+      });
+    });
+
+    it('ファイルが空の場合も正しく処理する', () => {
+      // Arrange
+      const githubCommitWithFiles: GitHubCommitWithFiles = {
+        sha: 'empty123',
+        commit: {
+          author: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          committer: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          message: 'Empty commit',
+          tree: { sha: 'tree123' },
+          comment_count: 0,
+        },
+        author: null,
+        committer: null,
+        parents: [],
+        html_url: 'https://github.com/owner/repo/commit/empty123',
+        files: [],
+        stats: {
+          total: 0,
+          additions: 0,
+          deletions: 0,
+        },
+      };
+
+      // Act
+      const result = convertToCommitDetail(githubCommitWithFiles);
+
+      // Assert
+      expect(result.sha).toBe('empty123');
+      expect(result.files).toEqual([]);
+      expect(result.stats).toEqual({
+        total: 0,
+        additions: 0,
+        deletions: 0,
+      });
+    });
+
+    it('様々なファイルステータスを正しく変換する', () => {
+      // Arrange
+      const githubCommitWithFiles: GitHubCommitWithFiles = {
+        sha: 'various123',
+        commit: {
+          author: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          committer: {
+            name: 'Test User',
+            email: 'test@example.com',
+            date: '2025-01-01T12:00:00Z',
+          },
+          message: 'Various changes',
+          tree: { sha: 'tree123' },
+          comment_count: 0,
+        },
+        author: null,
+        committer: null,
+        parents: [],
+        html_url: 'https://github.com/owner/repo/commit/various123',
+        files: [
+          { filename: 'added.ts', status: 'added', additions: 10, deletions: 0, changes: 10 },
+          { filename: 'removed.ts', status: 'removed', additions: 0, deletions: 20, changes: 20 },
+          { filename: 'modified.ts', status: 'modified', additions: 5, deletions: 3, changes: 8 },
+          {
+            filename: 'copied.ts',
+            status: 'copied',
+            additions: 0,
+            deletions: 0,
+            changes: 0,
+            previous_filename: 'original.ts',
+          },
+        ],
+        stats: {
+          total: 38,
+          additions: 15,
+          deletions: 23,
+        },
+      };
+
+      // Act
+      const result = convertToCommitDetail(githubCommitWithFiles);
+
+      // Assert
+      expect(result.files).toHaveLength(4);
+      expect(result.files[0].status).toBe('added');
+      expect(result.files[1].status).toBe('removed');
+      expect(result.files[2].status).toBe('modified');
+      expect(result.files[3].status).toBe('copied');
+      expect(result.files[3].previousFilename).toBe('original.ts');
     });
   });
 });

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -6,6 +6,23 @@ import { healthRouter } from './routes/health.js';
 import { createRepositoryRouter } from './routes/repository.js';
 
 /**
+ * 許可するオリジンのリストを取得
+ * 環境変数 FRONTEND_URL が設定されている場合はそれを使用
+ * 設定されていない場合は開発用のデフォルト値を使用
+ */
+const getAllowedOrigins = (): string[] => {
+  const envOrigin = process.env.FRONTEND_URL;
+
+  if (envOrigin) {
+    // 本番環境: 環境変数で指定されたオリジンのみ
+    return [envOrigin];
+  }
+
+  // 開発環境: Vite dev server と preview server の両方を許可
+  return ['http://localhost:5173', 'http://localhost:4173'];
+};
+
+/**
  * Expressアプリケーションの作成と設定
  * - ミドルウェアの設定
  * - ルーターの登録
@@ -19,7 +36,7 @@ export const createApp = (): Express => {
   // CORS設定: フロントエンドからのリクエストを許可
   app.use(
     cors({
-      origin: process.env.FRONTEND_URL ?? 'http://localhost:5173',
+      origin: getAllowedOrigins(),
       credentials: true, // Cookie送信を許可
     })
   );

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -7,18 +7,19 @@ import { createRepositoryRouter } from './routes/repository.js';
 
 /**
  * 許可するオリジンのリストを取得
- * 環境変数 FRONTEND_URL が設定されている場合はそれを使用
- * 設定されていない場合は開発用のデフォルト値を使用
+ * - 本番環境（NODE_ENV=production）: FRONTEND_URL のみ
+ * - 開発環境: Vite dev server (5173) と preview server (4173) の両方を許可
  */
 const getAllowedOrigins = (): string[] => {
+  const isProduction = process.env.NODE_ENV === 'production';
   const envOrigin = process.env.FRONTEND_URL;
 
-  if (envOrigin) {
+  if (isProduction && envOrigin) {
     // 本番環境: 環境変数で指定されたオリジンのみ
     return [envOrigin];
   }
 
-  // 開発環境: Vite dev server と preview server の両方を許可
+  // 開発環境: 両方のポートを許可（.env の FRONTEND_URL は無視）
   return ['http://localhost:5173', 'http://localhost:4173'];
 };
 

--- a/packages/backend/src/services/githubClient.ts
+++ b/packages/backend/src/services/githubClient.ts
@@ -1,4 +1,4 @@
-import type { GitHubBranch, GitHubCommit } from '@git-canvas/shared/types';
+import type { GitHubBranch, GitHubCommit, GitHubCommitWithFiles } from '@git-canvas/shared/types';
 
 /**
  * GitHub REST API クライアント
@@ -51,6 +51,28 @@ export class GitHubClient {
     const url = `${this.baseUrl}/repos/${owner}/${repo}/branches`;
 
     const response = await this.request<GitHubBranch[]>(url);
+    return response;
+  }
+
+  /**
+   * 単一コミットの詳細情報を取得（ファイル変更情報を含む）
+   *
+   * GitHub API: GET /repos/{owner}/{repo}/commits/{ref}
+   * 公式ドキュメント: https://docs.github.com/en/rest/commits/commits#get-a-commit
+   *
+   * @param owner - リポジトリオーナー
+   * @param repo - リポジトリ名
+   * @param sha - コミットSHA
+   * @returns ファイル変更情報を含むコミット詳細
+   */
+  async fetchCommitDetail(
+    owner: string,
+    repo: string,
+    sha: string
+  ): Promise<GitHubCommitWithFiles> {
+    const url = `${this.baseUrl}/repos/${owner}/${repo}/commits/${encodeURIComponent(sha)}`;
+
+    const response = await this.request<GitHubCommitWithFiles>(url);
     return response;
   }
 

--- a/packages/backend/src/services/githubConverter.ts
+++ b/packages/backend/src/services/githubConverter.ts
@@ -2,8 +2,11 @@ import type {
   CanvasAuthor,
   CanvasBranch,
   CanvasCommit,
+  CommitDetail,
+  CommitFile,
   GitHubBranch,
   GitHubCommit,
+  GitHubCommitWithFiles,
 } from '@git-canvas/shared/types';
 
 /**
@@ -62,5 +65,35 @@ export function convertToCanvasBranch(githubBranch: GitHubBranch): CanvasBranch 
     latestCommitId: githubBranch.commit.sha,
     isProtected: githubBranch.protected,
     // color は UI側で自動生成するため、ここでは undefined
+  };
+}
+
+/**
+ * GitHubCommitWithFiles を CommitDetail に変換
+ *
+ * @param githubCommit - GitHub API から取得したファイル情報付きコミット
+ * @returns UIレンダリング用に最適化されたコミット詳細情報
+ */
+export function convertToCommitDetail(githubCommit: GitHubCommitWithFiles): CommitDetail {
+  const { sha, files, stats } = githubCommit;
+
+  // ファイル情報を変換
+  const commitFiles: CommitFile[] = files.map((file) => ({
+    filename: file.filename,
+    status: file.status,
+    additions: file.additions,
+    deletions: file.deletions,
+    changes: file.changes,
+    previousFilename: file.previous_filename,
+  }));
+
+  return {
+    sha,
+    files: commitFiles,
+    stats: {
+      total: stats.total,
+      additions: stats.additions,
+      deletions: stats.deletions,
+    },
   };
 }

--- a/packages/backend/src/services/githubService.ts
+++ b/packages/backend/src/services/githubService.ts
@@ -2,10 +2,15 @@ import type {
   CanvasBranch,
   CanvasCommit,
   CanvasRepository,
+  CommitDetail,
   GitHubCommit,
 } from '@git-canvas/shared';
 import { GitHubClient } from './githubClient';
-import { convertToCanvasBranch, convertToCanvasCommit } from './githubConverter';
+import {
+  convertToCanvasBranch,
+  convertToCanvasCommit,
+  convertToCommitDetail,
+} from './githubConverter';
 
 /**
  * GitHub Service Module
@@ -159,5 +164,23 @@ export class GitHubService {
       commits,
       branches,
     };
+  }
+
+  /**
+   * 単一コミットの詳細情報を取得（ファイル変更情報を含む）
+   *
+   * @param owner - リポジトリオーナー
+   * @param repo - リポジトリ名
+   * @param sha - コミットSHA
+   * @returns ファイル変更情報を含むコミット詳細
+   */
+  public async getCommitDetail(owner: string, repo: string, sha: string): Promise<CommitDetail> {
+    // GitHub API からコミット詳細を取得
+    const githubCommit = await this.client.fetchCommitDetail(owner, repo, sha);
+
+    // Canvas型に変換
+    const commitDetail = convertToCommitDetail(githubCommit);
+
+    return commitDetail;
   }
 }

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // TypeScript ソースファイルのみをテスト対象にする
+    include: ['src/**/*.test.ts'],
+    // dist ディレクトリを除外
+    exclude: ['dist/**', 'node_modules/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/frontend/src/components/CommitDetailModal/CommitDetailModal.module.css
+++ b/packages/frontend/src/components/CommitDetailModal/CommitDetailModal.module.css
@@ -1,0 +1,268 @@
+/* CommitDetailModal.module.css */
+/* Apple風のデザインシステムを踏襲 */
+
+.backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95) 0%, rgba(248, 250, 252, 0.95) 100%);
+  border-radius: 20px;
+  box-shadow:
+    0 25px 50px -12px rgba(0, 0, 0, 0.25),
+    0 0 0 1px rgba(255, 255, 255, 0.1);
+  width: 90%;
+  max-width: 560px;
+  max-height: 85vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ヘッダー */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 1) 0%, rgba(248, 250, 252, 1) 100%);
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a2e;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mergeTag {
+  background: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%);
+  color: white;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.closeButton {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  color: #6b7280;
+  transition: all 0.2s ease;
+}
+
+.closeButton:hover {
+  background: rgba(0, 0, 0, 0.1);
+  color: #1a1a2e;
+}
+
+/* コンテンツ */
+.content {
+  padding: 24px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.section {
+  margin-bottom: 20px;
+}
+
+.section:last-child {
+  margin-bottom: 0;
+}
+
+.label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+/* SHA */
+.sha {
+  display: block;
+  font-family: "Fira Code", "SF Mono", Monaco, monospace;
+  font-size: 13px;
+  color: #1a1a2e;
+  background: rgba(59, 130, 246, 0.08);
+  padding: 10px 14px;
+  border-radius: 10px;
+  word-break: break-all;
+  user-select: all;
+}
+
+/* メッセージ */
+.message {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.6;
+  color: #1a1a2e;
+  background: rgba(0, 0, 0, 0.03);
+  padding: 14px 16px;
+  border-radius: 10px;
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* 作者 */
+.author {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 10px;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.authorName {
+  font-weight: 600;
+  color: #1a1a2e;
+  font-size: 14px;
+}
+
+.authorEmail {
+  color: #6b7280;
+  font-size: 13px;
+}
+
+/* 日付 */
+.date {
+  display: block;
+  font-size: 14px;
+  color: #1a1a2e;
+  padding: 10px 14px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 10px;
+}
+
+/* 親コミット */
+.parents {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.parentSha {
+  font-family: "Fira Code", "SF Mono", Monaco, monospace;
+  font-size: 12px;
+  color: #3b82f6;
+  background: rgba(59, 130, 246, 0.1);
+  padding: 6px 10px;
+  border-radius: 6px;
+}
+
+/* ブランチ */
+.branches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.branchTag {
+  font-size: 12px;
+  font-weight: 500;
+  color: #10b981;
+  background: rgba(16, 185, 129, 0.1);
+  padding: 6px 12px;
+  border-radius: 20px;
+}
+
+/* ファイル情報プレースホルダー */
+.filesPlaceholder {
+  font-size: 14px;
+  color: #9ca3af;
+  padding: 20px;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 10px;
+  border: 2px dashed rgba(0, 0, 0, 0.1);
+}
+
+/* フッター */
+.footer {
+  padding: 16px 24px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  background: rgba(248, 250, 252, 1);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.githubLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #3b82f6;
+  text-decoration: none;
+  padding: 10px 18px;
+  background: rgba(59, 130, 246, 0.1);
+  border-radius: 10px;
+  transition: all 0.2s ease;
+}
+
+.githubLink:hover {
+  background: rgba(59, 130, 246, 0.2);
+  color: #2563eb;
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 640px) {
+  .modal {
+    width: 95%;
+    max-height: 90vh;
+    border-radius: 16px;
+  }
+
+  .header {
+    padding: 16px 20px;
+  }
+
+  .content {
+    padding: 20px;
+  }
+
+  .author {
+    flex-wrap: wrap;
+  }
+
+  .authorEmail {
+    width: 100%;
+    margin-left: 42px;
+  }
+}

--- a/packages/frontend/src/components/CommitDetailModal/CommitDetailModal.module.css
+++ b/packages/frontend/src/components/CommitDetailModal/CommitDetailModal.module.css
@@ -22,7 +22,7 @@
     0 25px 50px -12px rgba(0, 0, 0, 0.25),
     0 0 0 1px rgba(255, 255, 255, 0.1);
   width: 90%;
-  max-width: 560px;
+  max-width: 600px;
   max-height: 85vh;
   overflow: hidden;
   display: flex;
@@ -95,7 +95,7 @@
   margin-bottom: 0;
 }
 
-.label {
+.sectionLabel {
   display: block;
   font-size: 12px;
   font-weight: 600;
@@ -202,15 +202,175 @@
   border-radius: 20px;
 }
 
-/* ファイル情報プレースホルダー */
-.filesPlaceholder {
+/* ファイル情報 - ローディング */
+.filesLoading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px;
+  color: #6b7280;
   font-size: 14px;
-  color: #9ca3af;
-  padding: 20px;
-  text-align: center;
   background: rgba(0, 0, 0, 0.03);
   border-radius: 10px;
-  border: 2px dashed rgba(0, 0, 0, 0.1);
+}
+
+.spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid rgba(59, 130, 246, 0.2);
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* ファイル情報 - エラー */
+.filesError {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 20px;
+  color: #ef4444;
+  font-size: 14px;
+  background: rgba(239, 68, 68, 0.08);
+  border-radius: 10px;
+  text-align: center;
+}
+
+.errorDetail {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+/* ファイル情報 - 統計サマリー */
+.statsSummary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 10px;
+  margin-bottom: 12px;
+  font-family: "Fira Code", "SF Mono", Monaco, monospace;
+  font-size: 13px;
+}
+
+.statsAdditions {
+  color: #10b981;
+  font-weight: 600;
+}
+
+.statsDeletions {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+.statsTotal {
+  color: #6b7280;
+  margin-left: auto;
+}
+
+/* ファイルリスト */
+.fileList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.fileItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  font-size: 13px;
+}
+
+.fileItem:last-child {
+  border-bottom: none;
+}
+
+.fileItem:hover {
+  background: rgba(59, 130, 246, 0.04);
+}
+
+/* ファイルステータスバッジ */
+.fileStatus {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 3px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+  min-width: 44px;
+  text-align: center;
+}
+
+.statusAdded {
+  background: rgba(16, 185, 129, 0.15);
+  color: #059669;
+}
+
+.statusRemoved {
+  background: rgba(239, 68, 68, 0.15);
+  color: #dc2626;
+}
+
+.statusModified {
+  background: rgba(245, 158, 11, 0.15);
+  color: #d97706;
+}
+
+.statusRenamed {
+  background: rgba(139, 92, 246, 0.15);
+  color: #7c3aed;
+}
+
+.statusDefault {
+  background: rgba(107, 114, 128, 0.15);
+  color: #4b5563;
+}
+
+/* ファイル名 */
+.fileName {
+  flex: 1;
+  font-family: "Fira Code", "SF Mono", Monaco, monospace;
+  color: #1a1a2e;
+  word-break: break-all;
+}
+
+.previousFileName {
+  color: #9ca3af;
+  text-decoration: line-through;
+}
+
+/* ファイル変更行数 */
+.fileChanges {
+  display: flex;
+  gap: 8px;
+  font-family: "Fira Code", "SF Mono", Monaco, monospace;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.fileAdditions {
+  color: #10b981;
+}
+
+.fileDeletions {
+  color: #ef4444;
 }
 
 /* フッター */
@@ -264,5 +424,19 @@
   .authorEmail {
     width: 100%;
     margin-left: 42px;
+  }
+
+  .fileItem {
+    flex-wrap: wrap;
+  }
+
+  .fileName {
+    width: 100%;
+    order: 2;
+    margin-top: 6px;
+  }
+
+  .fileChanges {
+    order: 1;
   }
 }

--- a/packages/frontend/src/components/CommitDetailModal/CommitDetailModal.tsx
+++ b/packages/frontend/src/components/CommitDetailModal/CommitDetailModal.tsx
@@ -1,0 +1,201 @@
+import type { CanvasCommit } from '@git-canvas/shared/types';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useCallback, useEffect } from 'react';
+import styles from './CommitDetailModal.module.css';
+
+interface CommitDetailModalProps {
+  /** 表示するコミット情報 */
+  commit: CanvasCommit;
+  /** モーダルを閉じる時のコールバック */
+  onClose: () => void;
+}
+
+/**
+ * コミット詳細を表示するモーダルコンポーネント
+ *
+ * 責務（SRP）:
+ * - コミットの基本情報を表示する
+ * - ESCキーや背景クリックで閉じる
+ *
+ * ファイル情報の取得・表示は別コンポーネントに委譲（Step 5で実装）
+ */
+export const CommitDetailModal = ({ commit, onClose }: CommitDetailModalProps) => {
+  // ESCキーでモーダルを閉じる
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  // 背景クリックでモーダルを閉じる
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  // 日付をフォーマット
+  const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  // マージコミット判定
+  const isMergeCommit = commit.parentIds.length >= 2;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className={styles.backdrop}
+        onClick={handleBackdropClick}
+        data-testid="modal-backdrop"
+        {...{
+          initial: { opacity: 0 },
+          animate: { opacity: 1 },
+          exit: { opacity: 0 },
+          transition: { duration: 0.2 },
+        }}
+      >
+        <motion.div
+          className={styles.modal}
+          role="dialog"
+          aria-labelledby="commit-detail-title"
+          aria-modal="true"
+          {...{
+            initial: { opacity: 0, scale: 0.9, y: 20 },
+            animate: { opacity: 1, scale: 1, y: 0 },
+            exit: { opacity: 0, scale: 0.9, y: 20 },
+            transition: { duration: 0.2, type: 'spring', damping: 25 },
+          }}
+        >
+          {/* ヘッダー */}
+          <div className={styles.header}>
+            <h2 id="commit-detail-title" className={styles.title}>
+              {isMergeCommit && <span className={styles.mergeTag}>Merge</span>}
+              コミット詳細
+            </h2>
+            <button
+              type="button"
+              className={styles.closeButton}
+              onClick={onClose}
+              aria-label="閉じる"
+              data-testid="close-button"
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* コンテンツ */}
+          <div className={styles.content}>
+            {/* SHA */}
+            <div className={styles.section}>
+              <span className={styles.sectionLabel}>SHA</span>
+              <code className={styles.sha} data-testid="commit-sha">
+                {commit.id}
+              </code>
+            </div>
+
+            {/* メッセージ */}
+            <div className={styles.section}>
+              <span className={styles.sectionLabel}>メッセージ</span>
+              <pre className={styles.message} data-testid="commit-message">
+                {commit.fullMessage}
+              </pre>
+            </div>
+
+            {/* 作者 */}
+            <div className={styles.section}>
+              <span className={styles.sectionLabel}>作者</span>
+              <div className={styles.author} data-testid="commit-author">
+                {commit.author.avatarUrl && (
+                  <img
+                    src={commit.author.avatarUrl}
+                    alt={`${commit.author.name}のアバター`}
+                    className={styles.avatar}
+                  />
+                )}
+                <span className={styles.authorName}>{commit.author.name}</span>
+                <span className={styles.authorEmail}>&lt;{commit.author.email}&gt;</span>
+              </div>
+            </div>
+
+            {/* 日付 */}
+            <div className={styles.section}>
+              <span className={styles.sectionLabel}>日時</span>
+              <time className={styles.date} dateTime={commit.date} data-testid="commit-date">
+                {formatDate(commit.date)}
+              </time>
+            </div>
+
+            {/* 親コミット */}
+            {commit.parentIds.length > 0 && (
+              <div className={styles.section}>
+                <span className={styles.sectionLabel}>
+                  親コミット {isMergeCommit && `(${commit.parentIds.length})`}
+                </span>
+                <div className={styles.parents} data-testid="commit-parents">
+                  {commit.parentIds.map((parentId) => (
+                    <code key={parentId} className={styles.parentSha}>
+                      {parentId.slice(0, 7)}
+                    </code>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* ブランチ */}
+            {commit.branchNames.length > 0 && (
+              <div className={styles.section}>
+                <span className={styles.sectionLabel}>ブランチ</span>
+                <div className={styles.branches} data-testid="commit-branches">
+                  {commit.branchNames.map((branch) => (
+                    <span key={branch} className={styles.branchTag}>
+                      {branch}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* ファイル情報プレースホルダー（Step 5で実装） */}
+            <div className={styles.section}>
+              <span className={styles.sectionLabel}>変更ファイル</span>
+              <div className={styles.filesPlaceholder} data-testid="files-placeholder">
+                ファイル情報は読み込み中...
+              </div>
+            </div>
+          </div>
+
+          {/* フッター */}
+          <div className={styles.footer}>
+            <a
+              href={commit.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.githubLink}
+              data-testid="github-link"
+            >
+              GitHubで見る ↗
+            </a>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+};

--- a/packages/frontend/src/components/CommitDetailModal/__tests__/CommitDetailModal.test.tsx
+++ b/packages/frontend/src/components/CommitDetailModal/__tests__/CommitDetailModal.test.tsx
@@ -1,7 +1,16 @@
-import type { CanvasCommit } from '@git-canvas/shared/types';
+import type { CanvasCommit, CommitDetail } from '@git-canvas/shared/types';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CommitDetailModal } from '../CommitDetailModal';
+
+// useCommitDetailフックをモック
+vi.mock('../../../hooks/useCommitDetail', () => ({
+  useCommitDetail: vi.fn(),
+}));
+
+import { useCommitDetail } from '../../../hooks/useCommitDetail';
+
+const mockUseCommitDetail = vi.mocked(useCommitDetail);
 
 describe('CommitDetailModal', () => {
   const mockCommit: CanvasCommit = {
@@ -20,134 +29,248 @@ describe('CommitDetailModal', () => {
     url: 'https://github.com/test/repo/commit/abc123def456789full',
   };
 
+  const mockCommitDetail: CommitDetail = {
+    sha: 'abc123def456789full',
+    files: [
+      {
+        filename: 'src/index.ts',
+        status: 'modified',
+        additions: 10,
+        deletions: 5,
+        changes: 15,
+      },
+      {
+        filename: 'README.md',
+        status: 'added',
+        additions: 20,
+        deletions: 0,
+        changes: 20,
+      },
+      {
+        filename: 'old-file.ts',
+        status: 'removed',
+        additions: 0,
+        deletions: 30,
+        changes: 30,
+      },
+    ],
+    stats: {
+      total: 65,
+      additions: 30,
+      deletions: 35,
+    },
+  };
+
   const mockOnClose = vi.fn();
+  const defaultProps = {
+    commit: mockCommit,
+    owner: 'testowner',
+    repo: 'testrepo',
+    onClose: mockOnClose,
+  };
 
   beforeEach(() => {
     mockOnClose.mockClear();
+    mockUseCommitDetail.mockReset();
   });
 
   describe('基本表示', () => {
+    beforeEach(() => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
+    });
+
     it('モーダルがレンダリングされる', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toBeInTheDocument();
     });
 
     it('コミットSHAが表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const sha = screen.getByTestId('commit-sha');
       expect(sha).toHaveTextContent('abc123def456789full');
     });
 
     it('完全なコミットメッセージが表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const message = screen.getByTestId('commit-message');
       expect(message).toHaveTextContent('Add new feature');
       expect(message).toHaveTextContent('This is a detailed description');
-      expect(message).toHaveTextContent('with multiple lines.');
     });
 
     it('作者情報が表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const author = screen.getByTestId('commit-author');
       expect(author).toHaveTextContent('Test User');
       expect(author).toHaveTextContent('test@example.com');
     });
 
-    it('作者のアバターが表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      const avatar = screen.getByAltText('Test Userのアバター');
-      expect(avatar).toHaveAttribute('src', 'https://example.com/avatar.png');
-    });
-
-    it('アバターURLがない場合はアバター画像が表示されない', () => {
-      const commitWithoutAvatar: CanvasCommit = {
-        ...mockCommit,
-        author: { name: 'No Avatar User', email: 'noavatar@example.com' },
-      };
-
-      render(<CommitDetailModal commit={commitWithoutAvatar} onClose={mockOnClose} />);
-
-      const avatar = screen.queryByRole('img');
-      expect(avatar).not.toBeInTheDocument();
-    });
-
-    it('日付がフォーマットされて表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      const date = screen.getByTestId('commit-date');
-      // 日本語フォーマットで表示される
-      expect(date).toHaveTextContent('2025');
-      expect(date).toHaveTextContent('1');
-      expect(date).toHaveTextContent('15');
-    });
-
-    it('親コミットが表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      const parents = screen.getByTestId('commit-parents');
-      expect(parents).toHaveTextContent('parent1'); // 7文字に短縮
-    });
-
-    it('ブランチ名が表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      const branches = screen.getByTestId('commit-branches');
-      expect(branches).toHaveTextContent('main');
-      expect(branches).toHaveTextContent('feature/test');
-    });
-
     it('GitHubリンクが正しいURLで表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const link = screen.getByTestId('github-link');
       expect(link).toHaveAttribute(
         'href',
         'https://github.com/test/repo/commit/abc123def456789full'
       );
-      expect(link).toHaveAttribute('target', '_blank');
-      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-    });
-
-    it('ファイル情報のプレースホルダーが表示される', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      const placeholder = screen.getByTestId('files-placeholder');
-      expect(placeholder).toBeInTheDocument();
     });
   });
 
-  describe('マージコミット', () => {
-    const mergeCommit: CanvasCommit = {
-      ...mockCommit,
-      parentIds: ['parent1', 'parent2'],
-      message: 'Merge branch feature into main',
-      fullMessage: 'Merge branch feature into main',
-    };
+  describe('ファイル情報の表示', () => {
+    it('ローディング中はスピナーが表示される', () => {
+      mockUseCommitDetail.mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: null,
+      });
 
-    it('マージコミットの場合はMergeタグが表示される', () => {
-      render(<CommitDetailModal commit={mergeCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
-      expect(screen.getByText('Merge')).toBeInTheDocument();
+      expect(screen.getByTestId('files-loading')).toBeInTheDocument();
+      expect(screen.getByText('ファイル情報を取得中...')).toBeInTheDocument();
     });
 
-    it('複数の親コミットが表示される', () => {
-      render(<CommitDetailModal commit={mergeCommit} onClose={mockOnClose} />);
+    it('エラー時はエラーメッセージが表示される', () => {
+      mockUseCommitDetail.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: new Error('Network error'),
+      });
 
-      const parents = screen.getByTestId('commit-parents');
-      expect(parents).toHaveTextContent('parent1');
-      expect(parents).toHaveTextContent('parent2');
+      render(<CommitDetailModal {...defaultProps} />);
+
+      expect(screen.getByTestId('files-error')).toBeInTheDocument();
+      expect(screen.getByText('ファイル情報の取得に失敗しました')).toBeInTheDocument();
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+
+    it('ファイル統計が表示される', () => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<CommitDetailModal {...defaultProps} />);
+
+      const stats = screen.getByTestId('files-stats');
+      expect(stats).toHaveTextContent('+30');
+      expect(stats).toHaveTextContent('-35');
+      expect(stats).toHaveTextContent('65 行変更');
+    });
+
+    it('ファイル一覧が表示される', () => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<CommitDetailModal {...defaultProps} />);
+
+      const fileList = screen.getByTestId('files-list');
+      expect(fileList).toBeInTheDocument();
+
+      expect(screen.getByText('src/index.ts')).toBeInTheDocument();
+      expect(screen.getByText('README.md')).toBeInTheDocument();
+      expect(screen.getByText('old-file.ts')).toBeInTheDocument();
+    });
+
+    it('ファイルステータスが正しく表示される', () => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<CommitDetailModal {...defaultProps} />);
+
+      expect(screen.getByText('変更')).toBeInTheDocument();
+      expect(screen.getByText('追加')).toBeInTheDocument();
+      expect(screen.getByText('削除')).toBeInTheDocument();
+    });
+
+    it('ファイル数がラベルに表示される', () => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<CommitDetailModal {...defaultProps} />);
+
+      expect(screen.getByText(/変更ファイル.*\(3\)/)).toBeInTheDocument();
+    });
+  });
+
+  describe('リネームファイルの表示', () => {
+    it('リネーム前のファイル名が表示される', () => {
+      const commitDetailWithRename: CommitDetail = {
+        sha: 'abc123',
+        files: [
+          {
+            filename: 'new-name.ts',
+            status: 'renamed',
+            additions: 0,
+            deletions: 0,
+            changes: 0,
+            previousFilename: 'old-name.ts',
+          },
+        ],
+        stats: { total: 0, additions: 0, deletions: 0 },
+      };
+
+      mockUseCommitDetail.mockReturnValue({
+        data: commitDetailWithRename,
+        isLoading: false,
+        error: null,
+      });
+
+      render(<CommitDetailModal {...defaultProps} />);
+
+      expect(screen.getByText('old-name.ts →')).toBeInTheDocument();
+      expect(screen.getByText('new-name.ts')).toBeInTheDocument();
+      expect(screen.getByText('名前変更')).toBeInTheDocument();
+    });
+  });
+
+  describe('useCommitDetailの呼び出し', () => {
+    it('正しいパラメータでuseCommitDetailが呼ばれる', () => {
+      mockUseCommitDetail.mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: null,
+      });
+
+      render(<CommitDetailModal {...defaultProps} />);
+
+      expect(mockUseCommitDetail).toHaveBeenCalledWith(
+        'testowner',
+        'testrepo',
+        'abc123def456789full'
+      );
     });
   });
 
   describe('閉じる操作', () => {
+    beforeEach(() => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
+    });
+
     it('閉じるボタンをクリックするとonCloseが呼ばれる', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const closeButton = screen.getByTestId('close-button');
       fireEvent.click(closeButton);
@@ -156,7 +279,7 @@ describe('CommitDetailModal', () => {
     });
 
     it('背景をクリックするとonCloseが呼ばれる', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const backdrop = screen.getByTestId('modal-backdrop');
       fireEvent.click(backdrop);
@@ -164,76 +287,57 @@ describe('CommitDetailModal', () => {
       expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
 
-    it('モーダル内部をクリックしてもonCloseは呼ばれない', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      const dialog = screen.getByRole('dialog');
-      fireEvent.click(dialog);
-
-      expect(mockOnClose).not.toHaveBeenCalled();
-    });
-
     it('ESCキーを押すとonCloseが呼ばれる', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       fireEvent.keyDown(document, { key: 'Escape' });
 
       expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
-
-    it('ESC以外のキーではonCloseは呼ばれない', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      fireEvent.keyDown(document, { key: 'Enter' });
-
-      expect(mockOnClose).not.toHaveBeenCalled();
-    });
   });
 
-  describe('エッジケース', () => {
-    it('親コミットがない場合は親コミットセクションが表示されない', () => {
-      const commitWithoutParent: CanvasCommit = {
-        ...mockCommit,
-        parentIds: [],
-      };
+  describe('マージコミット', () => {
+    const mergeCommit: CanvasCommit = {
+      ...mockCommit,
+      parentIds: ['parent1', 'parent2'],
+    };
 
-      render(<CommitDetailModal commit={commitWithoutParent} onClose={mockOnClose} />);
-
-      expect(screen.queryByTestId('commit-parents')).not.toBeInTheDocument();
+    beforeEach(() => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
     });
 
-    it('ブランチがない場合はブランチセクションが表示されない', () => {
-      const commitWithoutBranch: CanvasCommit = {
-        ...mockCommit,
-        branchNames: [],
-      };
+    it('マージコミットの場合はMergeタグが表示される', () => {
+      render(<CommitDetailModal {...defaultProps} commit={mergeCommit} />);
 
-      render(<CommitDetailModal commit={commitWithoutBranch} onClose={mockOnClose} />);
-
-      expect(screen.queryByTestId('commit-branches')).not.toBeInTheDocument();
+      expect(screen.getByText('Merge')).toBeInTheDocument();
     });
   });
 
   describe('アクセシビリティ', () => {
+    beforeEach(() => {
+      mockUseCommitDetail.mockReturnValue({
+        data: mockCommitDetail,
+        isLoading: false,
+        error: null,
+      });
+    });
+
     it('モーダルにaria-labelledbyが設定されている', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toHaveAttribute('aria-labelledby', 'commit-detail-title');
     });
 
     it('モーダルにaria-modal="true"が設定されている', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+      render(<CommitDetailModal {...defaultProps} />);
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toHaveAttribute('aria-modal', 'true');
-    });
-
-    it('閉じるボタンにaria-labelが設定されている', () => {
-      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
-
-      const closeButton = screen.getByTestId('close-button');
-      expect(closeButton).toHaveAttribute('aria-label', '閉じる');
     });
   });
 });

--- a/packages/frontend/src/components/CommitDetailModal/__tests__/CommitDetailModal.test.tsx
+++ b/packages/frontend/src/components/CommitDetailModal/__tests__/CommitDetailModal.test.tsx
@@ -1,0 +1,239 @@
+import type { CanvasCommit } from '@git-canvas/shared/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommitDetailModal } from '../CommitDetailModal';
+
+describe('CommitDetailModal', () => {
+  const mockCommit: CanvasCommit = {
+    id: 'abc123def456789full',
+    shortId: 'abc123d',
+    message: 'Add new feature',
+    fullMessage: 'Add new feature\n\nThis is a detailed description\nwith multiple lines.',
+    date: '2025-01-15T10:30:00Z',
+    author: {
+      name: 'Test User',
+      email: 'test@example.com',
+      avatarUrl: 'https://example.com/avatar.png',
+    },
+    parentIds: ['parent123'],
+    branchNames: ['main', 'feature/test'],
+    url: 'https://github.com/test/repo/commit/abc123def456789full',
+  };
+
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    mockOnClose.mockClear();
+  });
+
+  describe('基本表示', () => {
+    it('モーダルがレンダリングされる', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
+    });
+
+    it('コミットSHAが表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const sha = screen.getByTestId('commit-sha');
+      expect(sha).toHaveTextContent('abc123def456789full');
+    });
+
+    it('完全なコミットメッセージが表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const message = screen.getByTestId('commit-message');
+      expect(message).toHaveTextContent('Add new feature');
+      expect(message).toHaveTextContent('This is a detailed description');
+      expect(message).toHaveTextContent('with multiple lines.');
+    });
+
+    it('作者情報が表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const author = screen.getByTestId('commit-author');
+      expect(author).toHaveTextContent('Test User');
+      expect(author).toHaveTextContent('test@example.com');
+    });
+
+    it('作者のアバターが表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const avatar = screen.getByAltText('Test Userのアバター');
+      expect(avatar).toHaveAttribute('src', 'https://example.com/avatar.png');
+    });
+
+    it('アバターURLがない場合はアバター画像が表示されない', () => {
+      const commitWithoutAvatar: CanvasCommit = {
+        ...mockCommit,
+        author: { name: 'No Avatar User', email: 'noavatar@example.com' },
+      };
+
+      render(<CommitDetailModal commit={commitWithoutAvatar} onClose={mockOnClose} />);
+
+      const avatar = screen.queryByRole('img');
+      expect(avatar).not.toBeInTheDocument();
+    });
+
+    it('日付がフォーマットされて表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const date = screen.getByTestId('commit-date');
+      // 日本語フォーマットで表示される
+      expect(date).toHaveTextContent('2025');
+      expect(date).toHaveTextContent('1');
+      expect(date).toHaveTextContent('15');
+    });
+
+    it('親コミットが表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const parents = screen.getByTestId('commit-parents');
+      expect(parents).toHaveTextContent('parent1'); // 7文字に短縮
+    });
+
+    it('ブランチ名が表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const branches = screen.getByTestId('commit-branches');
+      expect(branches).toHaveTextContent('main');
+      expect(branches).toHaveTextContent('feature/test');
+    });
+
+    it('GitHubリンクが正しいURLで表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const link = screen.getByTestId('github-link');
+      expect(link).toHaveAttribute(
+        'href',
+        'https://github.com/test/repo/commit/abc123def456789full'
+      );
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('ファイル情報のプレースホルダーが表示される', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const placeholder = screen.getByTestId('files-placeholder');
+      expect(placeholder).toBeInTheDocument();
+    });
+  });
+
+  describe('マージコミット', () => {
+    const mergeCommit: CanvasCommit = {
+      ...mockCommit,
+      parentIds: ['parent1', 'parent2'],
+      message: 'Merge branch feature into main',
+      fullMessage: 'Merge branch feature into main',
+    };
+
+    it('マージコミットの場合はMergeタグが表示される', () => {
+      render(<CommitDetailModal commit={mergeCommit} onClose={mockOnClose} />);
+
+      expect(screen.getByText('Merge')).toBeInTheDocument();
+    });
+
+    it('複数の親コミットが表示される', () => {
+      render(<CommitDetailModal commit={mergeCommit} onClose={mockOnClose} />);
+
+      const parents = screen.getByTestId('commit-parents');
+      expect(parents).toHaveTextContent('parent1');
+      expect(parents).toHaveTextContent('parent2');
+    });
+  });
+
+  describe('閉じる操作', () => {
+    it('閉じるボタンをクリックするとonCloseが呼ばれる', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const closeButton = screen.getByTestId('close-button');
+      fireEvent.click(closeButton);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('背景をクリックするとonCloseが呼ばれる', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const backdrop = screen.getByTestId('modal-backdrop');
+      fireEvent.click(backdrop);
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('モーダル内部をクリックしてもonCloseは呼ばれない', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const dialog = screen.getByRole('dialog');
+      fireEvent.click(dialog);
+
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+
+    it('ESCキーを押すとonCloseが呼ばれる', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('ESC以外のキーではonCloseは呼ばれない', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      fireEvent.keyDown(document, { key: 'Enter' });
+
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('親コミットがない場合は親コミットセクションが表示されない', () => {
+      const commitWithoutParent: CanvasCommit = {
+        ...mockCommit,
+        parentIds: [],
+      };
+
+      render(<CommitDetailModal commit={commitWithoutParent} onClose={mockOnClose} />);
+
+      expect(screen.queryByTestId('commit-parents')).not.toBeInTheDocument();
+    });
+
+    it('ブランチがない場合はブランチセクションが表示されない', () => {
+      const commitWithoutBranch: CanvasCommit = {
+        ...mockCommit,
+        branchNames: [],
+      };
+
+      render(<CommitDetailModal commit={commitWithoutBranch} onClose={mockOnClose} />);
+
+      expect(screen.queryByTestId('commit-branches')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('アクセシビリティ', () => {
+    it('モーダルにaria-labelledbyが設定されている', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'commit-detail-title');
+    });
+
+    it('モーダルにaria-modal="true"が設定されている', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('閉じるボタンにaria-labelが設定されている', () => {
+      render(<CommitDetailModal commit={mockCommit} onClose={mockOnClose} />);
+
+      const closeButton = screen.getByTestId('close-button');
+      expect(closeButton).toHaveAttribute('aria-label', '閉じる');
+    });
+  });
+});

--- a/packages/frontend/src/components/GitGraph/GitGraph.tsx
+++ b/packages/frontend/src/components/GitGraph/GitGraph.tsx
@@ -7,9 +7,11 @@ import styles from './GitGraph.module.css';
 interface GitGraphProps {
   commits: CanvasCommit[];
   branches?: CanvasBranch[];
+  /** コミットノードがクリックされた時のコールバック */
+  onCommitClick?: (commit: CanvasCommit) => void;
 }
 
-export const GitGraph = ({ commits, branches = [] }: GitGraphProps) => {
+export const GitGraph = ({ commits, branches = [], onCommitClick }: GitGraphProps) => {
   const layout = calculateGitGraphLayout(commits, branches, {
     nodeSpacing: 80,
     laneHeight: 60,
@@ -39,6 +41,11 @@ export const GitGraph = ({ commits, branches = [] }: GitGraphProps) => {
   // viewBox: グラフを中央に配置
   const viewBoxY = 150;
   const viewBoxHeight = contentHeight - viewBoxY + 200;
+
+  // コミットノードクリック時のハンドラー
+  const handleCommitClick = (commit: CanvasCommit) => {
+    onCommitClick?.(commit);
+  };
 
   return (
     <div className={styles.wrapper}>
@@ -155,6 +162,9 @@ export const GitGraph = ({ commits, branches = [] }: GitGraphProps) => {
                     stroke="white"
                     strokeWidth={2.5}
                     className={styles.commitNode}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => handleCommitClick(node)}
+                    data-testid={`commit-node-${node.shortId}`}
                     {...{
                       initial: { scale: 0 },
                       animate: { scale: 1 },
@@ -181,6 +191,9 @@ export const GitGraph = ({ commits, branches = [] }: GitGraphProps) => {
                     stroke="white"
                     strokeWidth={2.5}
                     className={styles.commitNode}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => handleCommitClick(node)}
+                    data-testid={`commit-node-${node.shortId}`}
                     {...{
                       initial: { scale: 0 },
                       animate: { scale: 1 },

--- a/packages/frontend/src/components/Repository/RepositoryViewer.tsx
+++ b/packages/frontend/src/components/Repository/RepositoryViewer.tsx
@@ -1,4 +1,7 @@
+import type { CanvasCommit } from '@git-canvas/shared/types';
+import { useState } from 'react';
 import { useRepository } from '../../hooks/useRepository';
+import { CommitDetailModal } from '../CommitDetailModal/CommitDetailModal';
 import { GitGraph } from '../GitGraph/GitGraph';
 import styles from './RepositoryViewer.module.css';
 
@@ -15,6 +18,19 @@ interface RepositoryViewerProps {
  */
 export const RepositoryViewer = ({ owner, repo }: RepositoryViewerProps) => {
   const { repository, loading, error, refetch } = useRepository(owner, repo);
+
+  // コミット詳細モーダル用の状態
+  const [selectedCommit, setSelectedCommit] = useState<CanvasCommit | null>(null);
+
+  // コミットノードがクリックされた時のハンドラ
+  const handleCommitClick = (commit: CanvasCommit) => {
+    setSelectedCommit(commit);
+  };
+
+  // モーダルを閉じる時のハンドラ
+  const handleCloseModal = () => {
+    setSelectedCommit(null);
+  };
 
   if (loading) {
     return (
@@ -67,7 +83,11 @@ export const RepositoryViewer = ({ owner, repo }: RepositoryViewerProps) => {
       {/* Git グラフ */}
       <section className={styles.section}>
         <h3 className={styles.sectionTitle}>Commit Graph</h3>
-        <GitGraph commits={repository.commits} branches={repository.branches} />
+        <GitGraph
+          commits={repository.commits}
+          branches={repository.branches}
+          onCommitClick={handleCommitClick}
+        />
       </section>
 
       {/* ブランチセクション */}
@@ -116,6 +136,16 @@ export const RepositoryViewer = ({ owner, repo }: RepositoryViewerProps) => {
           ))}
         </div>
       </section>
+
+      {/* コミット詳細モーダル */}
+      {selectedCommit && (
+        <CommitDetailModal
+          commit={selectedCommit}
+          owner={owner}
+          repo={repo}
+          onClose={handleCloseModal}
+        />
+      )}
     </div>
   );
 };

--- a/packages/frontend/src/hooks/__tests__/useCommitDetail.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useCommitDetail.test.ts
@@ -1,0 +1,213 @@
+import type { CommitDetail } from '@git-canvas/shared/types';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { useCommitDetail } from '../useCommitDetail';
+
+describe('useCommitDetail', () => {
+  const mockCommitDetail: CommitDetail = {
+    sha: 'abc123def456',
+    files: [
+      {
+        filename: 'src/index.ts',
+        status: 'modified',
+        additions: 10,
+        deletions: 5,
+        changes: 15,
+      },
+      {
+        filename: 'README.md',
+        status: 'added',
+        additions: 20,
+        deletions: 0,
+        changes: 20,
+      },
+    ],
+    stats: {
+      total: 35,
+      additions: 30,
+      deletions: 5,
+    },
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('初期状態はローディング中である', () => {
+    // Arrange
+    vi.spyOn(global, 'fetch').mockImplementation(
+      () => new Promise(() => {}) // 永遠に解決しないPromise
+    );
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('owner', 'repo', 'sha123'));
+
+    // Assert
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('正常にデータを取得できる', async () => {
+    // Arrange
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCommitDetail),
+    } as Response);
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('owner', 'repo', 'abc123def456'));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(mockCommitDetail);
+    expect(result.current.error).toBeNull();
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/repositories/owner/repo/commits/abc123def456',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('APIエラー時にエラー状態になる', async () => {
+    // Arrange
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as Response);
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('owner', 'repo', 'notfound'));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toContain('404');
+  });
+
+  it('ネットワークエラー時にエラー状態になる', async () => {
+    // Arrange
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('owner', 'repo', 'sha123'));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('Network error');
+  });
+
+  it('パラメータが変更されると再取得する', async () => {
+    // Arrange
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCommitDetail),
+    } as Response);
+
+    // Act
+    const { result, rerender } = renderHook(
+      ({ owner, repo, sha }) => useCommitDetail(owner, repo, sha),
+      { initialProps: { owner: 'owner1', repo: 'repo1', sha: 'sha1' } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // パラメータを変更
+    rerender({ owner: 'owner2', repo: 'repo2', sha: 'sha2' });
+
+    // Assert
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      '/api/repositories/owner2/repo2/commits/sha2',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('ownerが空の場合はAPIを呼び出さない', async () => {
+    // Arrange
+    const fetchSpy = vi.spyOn(global, 'fetch');
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('', 'repo', 'sha'));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+  });
+
+  it('repoが空の場合はAPIを呼び出さない', async () => {
+    // Arrange
+    const fetchSpy = vi.spyOn(global, 'fetch');
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('owner', '', 'sha'));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('shaが空の場合はAPIを呼び出さない', async () => {
+    // Arrange
+    const fetchSpy = vi.spyOn(global, 'fetch');
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('owner', 'repo', ''));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('特殊文字を含むパラメータがエンコードされる', async () => {
+    // Arrange
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockCommitDetail),
+    } as Response);
+
+    // Act
+    const { result } = renderHook(() => useCommitDetail('owner/special', 'repo name', 'sha#123'));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/repositories/owner%2Fspecial/repo%20name/commits/sha%23123',
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/frontend/src/hooks/__tests__/useCommitDetail.test.ts
+++ b/packages/frontend/src/hooks/__tests__/useCommitDetail.test.ts
@@ -1,6 +1,6 @@
 import type { CommitDetail } from '@git-canvas/shared/types';
 import { renderHook, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCommitDetail } from '../useCommitDetail';
 
 describe('useCommitDetail', () => {

--- a/packages/frontend/src/hooks/useCommitDetail.ts
+++ b/packages/frontend/src/hooks/useCommitDetail.ts
@@ -1,0 +1,97 @@
+import type { CommitDetail } from '@git-canvas/shared/types';
+import { useEffect, useState } from 'react';
+
+/**
+ * useCommitDetail の戻り値の型
+ */
+interface UseCommitDetailResult {
+  /** コミット詳細データ（取得完了後） */
+  data: CommitDetail | null;
+  /** ローディング中フラグ */
+  isLoading: boolean;
+  /** エラー情報（エラー発生時） */
+  error: Error | null;
+}
+
+/**
+ * コミット詳細情報を取得するカスタムフック
+ *
+ * 責務（SRP）:
+ * - コミット詳細APIの呼び出し
+ * - ローディング状態の管理
+ * - エラー状態の管理
+ *
+ * @param owner - リポジトリオーナー
+ * @param repo - リポジトリ名
+ * @param sha - コミットSHA
+ * @returns コミット詳細データ、ローディング状態、エラー状態
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, error } = useCommitDetail('octocat', 'hello-world', 'abc123');
+ *
+ * if (isLoading) return <Spinner />;
+ * if (error) return <ErrorMessage error={error} />;
+ * if (data) return <FileList files={data.files} />;
+ * ```
+ */
+export const useCommitDetail = (
+  owner: string,
+  repo: string,
+  sha: string
+): UseCommitDetailResult => {
+  const [data, setData] = useState<CommitDetail | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    // パラメータが不正な場合は何もしない
+    if (!owner || !repo || !sha) {
+      setIsLoading(false);
+      return;
+    }
+
+    // 状態をリセット
+    setData(null);
+    setError(null);
+    setIsLoading(true);
+
+    // AbortController でキャンセル可能にする
+    const abortController = new AbortController();
+
+    const fetchCommitDetail = async () => {
+      try {
+        const response = await fetch(
+          `/api/repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(sha)}`,
+          { signal: abortController.signal }
+        );
+
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch commit detail: ${response.status} ${response.statusText}`
+          );
+        }
+
+        const commitDetail: CommitDetail = await response.json();
+        setData(commitDetail);
+      } catch (err) {
+        // AbortError は無視（コンポーネントのアンマウント時）
+        if (err instanceof Error && err.name === 'AbortError') {
+          return;
+        }
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCommitDetail();
+
+    // クリーンアップ: コンポーネントアンマウント時にリクエストをキャンセル
+    return () => {
+      abortController.abort();
+    };
+  }, [owner, repo, sha]);
+
+  return { data, isLoading, error };
+};

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -4,4 +4,13 @@ import { defineConfig } from 'vite';
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      // /api へのリクエストをバックエンドに転送
+      '/api': {
+        target: 'http://localhost:3000', // バックエンドのポート
+        changeOrigin: true,
+      },
+    },
+  },
 });

--- a/packages/shared/src/types/canvas.ts
+++ b/packages/shared/src/types/canvas.ts
@@ -78,3 +78,55 @@ export interface CanvasRepository {
   /** ブランチリスト */
   branches: CanvasBranch[];
 }
+
+/**
+ * コミットで変更されたファイルの情報
+ */
+export interface CommitFile {
+  /** ファイル名（パス付き） */
+  filename: string;
+
+  /** ファイルの変更ステータス */
+  status: 'added' | 'removed' | 'modified' | 'renamed' | 'copied' | 'changed' | 'unchanged';
+
+  /** 追加行数 */
+  additions: number;
+
+  /** 削除行数 */
+  deletions: number;
+
+  /** 変更行数（additions + deletions） */
+  changes: number;
+
+  /** リネーム前のファイル名（status が renamed の場合のみ） */
+  previousFilename?: string;
+}
+
+/**
+ * コミットの変更統計情報
+ */
+export interface CommitStats {
+  /** 総変更行数 */
+  total: number;
+
+  /** 追加行数 */
+  additions: number;
+
+  /** 削除行数 */
+  deletions: number;
+}
+
+/**
+ * コミット詳細情報（ファイル変更情報を含む）
+ * モーダル表示用に最適化
+ */
+export interface CommitDetail {
+  /** コミットSHA */
+  sha: string;
+
+  /** 変更ファイル一覧 */
+  files: CommitFile[];
+
+  /** 変更統計 */
+  stats: CommitStats;
+}

--- a/packages/shared/src/types/github.ts
+++ b/packages/shared/src/types/github.ts
@@ -63,3 +63,56 @@ export interface GitHubBranch {
   };
   protected: boolean;
 }
+
+/**
+ * コミットで変更されたファイルの情報（GitHub API レスポンス）
+ * GET /repos/{owner}/{repo}/commits/{ref} のレスポンスに含まれる
+ */
+export interface GitHubCommitFile {
+  /** ファイル名（パス付き） */
+  filename: string;
+
+  /** ファイルの変更ステータス */
+  status: 'added' | 'removed' | 'modified' | 'renamed' | 'copied' | 'changed' | 'unchanged';
+
+  /** 追加行数 */
+  additions: number;
+
+  /** 削除行数 */
+  deletions: number;
+
+  /** 変更行数 */
+  changes: number;
+
+  /** パッチ内容（diff） */
+  patch?: string;
+
+  /** リネーム前のファイル名 */
+  previous_filename?: string;
+}
+
+/**
+ * コミット統計情報（GitHub API レスポンス）
+ */
+export interface GitHubCommitStats {
+  /** 総変更行数 */
+  total: number;
+
+  /** 追加行数 */
+  additions: number;
+
+  /** 削除行数 */
+  deletions: number;
+}
+
+/**
+ * 単一コミットの詳細情報（ファイル情報付き）
+ * GET /repos/{owner}/{repo}/commits/{ref} のレスポンス
+ */
+export interface GitHubCommitWithFiles extends GitHubCommit {
+  /** 変更ファイル一覧 */
+  files: GitHubCommitFile[];
+
+  /** 変更統計 */
+  stats: GitHubCommitStats;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -3,7 +3,15 @@
  */
 export type { HealthResponse, HealthStatus } from './api.js';
 export type { AuthStatusResponse, AuthUser } from './auth.js';
-export type { CanvasAuthor, CanvasBranch, CanvasCommit, CanvasRepository } from './canvas.js';
+export type {
+  CanvasAuthor,
+  CanvasBranch,
+  CanvasCommit,
+  CanvasRepository,
+  CommitDetail,
+  CommitFile,
+  CommitStats,
+} from './canvas.js';
 export type { ErrorResponse } from './error.js';
 export type {
   BranchLane,
@@ -17,5 +25,8 @@ export type {
   GitHubCommit,
   GitHubCommitAuthor,
   GitHubCommitDetail,
+  GitHubCommitFile,
+  GitHubCommitStats,
+  GitHubCommitWithFiles,
   GitHubUser,
 } from './github.js';


### PR DESCRIPTION
## 概要

コミットノードをクリックすると詳細情報をモーダルで表示する機能を実装

## 変更内容

### 機能
- コミットノードのクリックイベント
- コミット詳細モーダル（基本情報 + ファイル変更情報）
- ファイル情報の遅延取得（ハイブリッド方式）

## スクリーンショット



## 確認事項
- [x] 全テスト通過
- [x] TypeScript コンパイル成功
- [x] 開発環境で動作確認
- [x] 本番プレビューで動作確認